### PR TITLE
a few improvements in error handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .*.log
+/sdists-repo/

--- a/extract-requires.py
+++ b/extract-requires.py
@@ -1,9 +1,10 @@
 import argparse
 import os
 import sys
+
+import pyproject_hooks
 import toml
 from packaging import metadata
-import pyproject_hooks
 
 # Extract requirements from a pyproject.toml
 #

--- a/extract-requires.py
+++ b/extract-requires.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
         with open(os.path.join(metadata_path, "METADATA"), "r") as f:
             parsed = metadata.Metadata.from_email(f.read())
-            for r in parsed.requires_dist:
+            for r in (parsed.requires_dist or []):
                 if not r.marker:
                     requires.append(str(r))
     elif args.build_system:

--- a/extract-requires.py
+++ b/extract-requires.py
@@ -59,7 +59,7 @@ if __name__ == "__main__":
         metadata_path = hook_caller.prepare_metadata_for_build_wheel("./")
 
         with open(os.path.join(metadata_path, "METADATA"), "r") as f:
-            parsed = metadata.Metadata.from_email(f.read())
+            parsed = metadata.Metadata.from_email(f.read(), validate=False)
             for r in (parsed.requires_dist or []):
                 if not r.marker:
                     requires.append(str(r))

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -74,6 +74,9 @@ collect_build_requires() {
     local pyproject_toml=$(ls -1 $tmp_unpack_dir/*/pyproject.toml)
     local extract_script=$(pwd)/extract-requires.py
 
+    echo "Processing ${sdist} with pyproject.toml:"
+    cat "${pyproject_toml}"
+
     (cd $(dirname $pyproject_toml) && $PYTHON $extract_script --build-system < pyproject.toml) | while read -r req_iter; do
       local req_sdist=$(download_sdist "${req_iter}")
       if [ -n "${req_sdist}" ]; then

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -27,7 +27,7 @@ setup() {
 
 setup
 
-pip install -U python-pypi-mirror toml pyproject_hooks packaging
+pip install -U python-pypi-mirror toml pyproject_hooks packaging wheel
 
 # cmake needed, otherwise:
 # Building wheels for collected packages: patchelf, ninja

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -92,6 +92,11 @@ collect_build_requires() {
         collect_build_requires "${req_sdist}"
 
         add_to_build_order "build_backend" "${req_iter}"
+
+        # Build backends are often used to package themselves, so in
+        # order to determine their dependencies they may need to be
+        # installed.
+        pip install -U "${req_iter}"
       fi
     done
 

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -8,22 +8,27 @@ export PS4='+ ${BASH_SOURCE#$HOME/}:$LINENO \011'
 logfile=".mirror_$(date '+%Y-%m-%d_%H-%M-%S').log"
 exec > >(tee "$logfile") 2>&1
 
+TMP=$(mktemp --tmpdir=. --directory tmpXXXX)
+
 #TOPLEVEL="hatchling"
 #TOPLEVEL="frozenlist"
 TOPLEVEL="langchain"
 
-VENV=$(basename $(mktemp --dry-run --directory --tmpdir=. venvXXXX))
+VENV=$TMP/venv
+#VENV=venv
 PYTHON=python3.9
 
 on_exit() {
   rm -rf $VENV/
 }
-trap on_exit EXIT
+#trap on_exit EXIT
 
 setup() {
-  $PYTHON -m venv $VENV
-  . ./$VENV/bin/activate
-  pip install -U pip
+    if [ ! -d $VENV ]; then
+        $PYTHON -m venv $VENV
+    fi
+    . ./$VENV/bin/activate
+    pip install -U pip
 }
 
 setup
@@ -67,7 +72,7 @@ download_sdist() {
 collect_build_requires() {
   local sdist="$1"; shift
 
-  local tmp_unpack_dir=$(mktemp --tmpdir=. --directory tmpXXXX)
+  local tmp_unpack_dir=$(mktemp --tmpdir=$TMP --directory tmpXXXX)
   tar -C $tmp_unpack_dir -xvzf $sdist
 
   if [ -e $tmp_unpack_dir/*/pyproject.toml ]; then

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -16,7 +16,7 @@ TOPLEVEL="langchain"
 
 VENV=$TMP/venv
 #VENV=venv
-PYTHON=python3.9
+PYTHON=python3
 
 on_exit() {
   rm -rf $VENV/

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -xe
+set -o pipefail
 
 # Redirect stdout/stderr to logfile
 logfile=".mirror_$(date '+%Y-%m-%d_%H-%M-%S').log"

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -12,7 +12,7 @@ TMP=$(mktemp --tmpdir=. --directory tmpXXXX)
 
 #TOPLEVEL="hatchling"
 #TOPLEVEL="frozenlist"
-TOPLEVEL="langchain"
+TOPLEVEL="${1:langchain}"
 
 VENV=$TMP/venv
 #VENV=venv

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -2,6 +2,7 @@
 
 set -xe
 set -o pipefail
+export PS4='+ ${BASH_SOURCE#$HOME/}:$LINENO \011'
 
 # Redirect stdout/stderr to logfile
 logfile=".mirror_$(date '+%Y-%m-%d_%H-%M-%S').log"

--- a/parse_dep.py
+++ b/parse_dep.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+
+import sys
+
+from packaging import requirements
+
+req = requirements.Requirement(sys.argv[1])
+print(req.name)

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+sudo dnf install python3 python3-devel rust cargo cmake autoconf automake


### PR DESCRIPTION
* show contents of pyproject.toml before processing it
* install build backends
* set PS4 to show the filename and linenumber of commands
* do not validate metadata when parsing
* ensure the venv has the wheel package
* handle None for requires_dist
* show hook output
* set pipefail so the script exits if anything breaks
* ignore the sdists-repo output directory