### PR TITLE
corrections to installation step of build backends

### DIFF
--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -93,11 +93,6 @@ collect_build_requires() {
         collect_build_requires "${req_sdist}"
 
         add_to_build_order "build_backend" "${req_iter}"
-
-        # Build backends are often used to package themselves, so in
-        # order to determine their dependencies they may need to be
-        # installed.
-        pip install -U "${req_iter}"
       fi
     done
 


### PR DESCRIPTION
The metadata collection for build backends seems to understand the
`backend-path` setting, so there is no need to install them before getting
their own metadata.

When we see a build tool enter the set of packages being processed, there
is a good chance we will see circular dependencies with other things also
being packaged with that tool, including 2nd or 3rd order dependencies of
the tool itself. For example, plugins to the tool often depend on the tool.
The code for looking up the metadata of a project can cope with
`backend-path` being set, but that does not help
*later* dependencies, so we install the tool to ensure it is present when
required. This introduces an undesirable dependency on having these build
tools in the system already, so we may end up wanting to treat them as
special