### PR TITLE
handle all requirements, regardless of whether there is a marker

### DIFF
--- a/extract-requires.py
+++ b/extract-requires.py
@@ -87,8 +87,7 @@ if __name__ == "__main__":
         with open(os.path.join(metadata_path, "METADATA"), "r") as f:
             parsed = metadata.Metadata.from_email(f.read(), validate=False)
             for r in (parsed.requires_dist or []):
-                if not r.marker:
-                    requires.append(str(r))
+                requires.append(str(r))
     elif args.build_system:
         requires.extend(get_build_backend(pyproject_toml)['requires'])
     elif args.build_backend:


### PR DESCRIPTION
This ensures that everything needed to build the package is downloaded by the mirror script.

Fixes #3