### PR TITLE
fixes for building projects without pyproject.toml files

### DIFF
--- a/extract-requires.py
+++ b/extract-requires.py
@@ -75,7 +75,11 @@ if __name__ == "__main__":
     parser.add_argument("--build-backend", action=argparse.BooleanOptionalAction)
     args = parser.parse_args()
 
-    pyproject_toml = toml.loads(sys.stdin.read())
+    if not os.path.exists('pyproject.toml'):
+        pyproject_toml = {}
+    else:
+        with open('pyproject.toml', 'r') as f:
+            pyproject_toml = toml.loads(f.read())
     hook_caller = get_build_backend_hook_caller(pyproject_toml)
 
     requires = []

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -13,7 +13,7 @@ TMP=$(mktemp --tmpdir=. --directory tmpXXXX)
 TOPLEVEL="${1:-langchain}"
 
 VENV=$TMP/venv
-PYTHON=python3
+PYTHON=python3.9
 
 on_exit() {
   rm -rf $TMP/


### PR DESCRIPTION
* cope with projects that have no pyproject.toml at all
* handle all requirements, regardless of whether there is a marker

Fixes #9 