### PR TITLE
Fix extras handling

### DIFF
--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -111,7 +111,7 @@ collect_build_requires() {
       download_sdist "${req_iter}" | tee $download_output
       local req_sdist=$(get_downloaded_sdist $download_output)
       if [ -n "${req_sdist}" ]; then
-        collect_build_requires "${req}" "${req_sdist}" "${why} -> ${next_why}"
+        collect_build_requires "${req_iter}" "${req_sdist}" "${why} -> ${next_why}"
 
         add_to_build_order "build_system" "${req_iter}" "${why}"
 
@@ -130,7 +130,7 @@ collect_build_requires() {
     download_sdist "${req_iter}" | tee $download_output
     local req_sdist=$(get_downloaded_sdist $download_output)
     if [ -n "${req_sdist}" ]; then
-      collect_build_requires "${req}" "${req_sdist}" "${why} -> ${next_why}"
+      collect_build_requires "${req_iter}" "${req_sdist}" "${why} -> ${next_why}"
 
       add_to_build_order "build_backend" "${req_iter}" "${why}"
 
@@ -153,7 +153,7 @@ collect_build_requires() {
     download_sdist "${req_iter}" | tee $download_output
     local req_sdist=$(get_downloaded_sdist $download_output)
     if [ -n "${req_sdist}" ]; then
-      collect_build_requires "${req}" "${req_sdist}" "${why} -> ${next_why}"
+      collect_build_requires "${req_iter}" "${req_sdist}" "${why} -> ${next_why}"
 
       add_to_build_order "dependency" "${req_iter}" "${why}"
     fi


### PR DESCRIPTION
Two issues

1. We're not passing the correct requirement specifier as we recurse into collect_build_requires(), so we're always evaluating using the environment markers of the toplevel as context
2. We're not correctly setting up the context environment for marker evaluation - a requirement may specify multiple extras, but a context environment can only have one `extra` key