### PR TITLE
Evaluate standard environment markers

### DIFF
--- a/extract-requires.py
+++ b/extract-requires.py
@@ -5,6 +5,7 @@ import sys
 
 import pyproject_hooks
 import tomli
+from packaging import markers
 from packaging import metadata
 from packaging.requirements import Requirement
 
@@ -70,6 +71,19 @@ def get_build_backend_hook_caller(pyproject_toml):
     )
 
 
+def evaluate_marker(req, extras=None):
+    marker_env = markers.default_environment()
+    for extra in extras if extras else [""]:
+        if extra:
+            marker_env['extra'] = extra
+        if (not req.marker) or req.marker.evaluate(marker_env):
+            print(f'adding {req} via extra="{extra}"', file=sys.stderr)
+            return True
+        else:
+            print(f'ignoring {req} because marker evaluates false with context {marker_env}', file=sys.stderr)
+    return False
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--build-system", action=argparse.BooleanOptionalAction)
@@ -94,20 +108,17 @@ if __name__ == "__main__":
 
         with open(os.path.join(metadata_path, "METADATA"), "r") as f:
             parsed = metadata.Metadata.from_email(f.read(), validate=False)
-            for extra in original_requirement.extras if original_requirement.extras else [""]:
-                extra_marker_env = {}
-                if extra:
-                    extra_marker_env['extra'] = extra
-                for r in (parsed.requires_dist or []):
-                    if (not r.marker) or r.marker.evaluate(extra_marker_env):
-                        print(f'adding {r} within context {extra_marker_env}', file=sys.stderr)
-                        requires.add(str(r))
-                    else:
-                        print(f'ignoring {r} because marker evaluates false with context {extra_marker_env}', file=sys.stderr)
+            for r in (parsed.requires_dist or []):
+                if evaluate_marker(r, original_requirement.extras):
+                    requires.add(str(r))
     elif args.build_system:
-        requires.update(get_build_backend(pyproject_toml)['requires'])
+        for r in get_build_backend(pyproject_toml)['requires']:
+            if evaluate_marker(Requirement(r)):
+                requires.add(r)
     elif args.build_backend:
-        requires.update(hook_caller.get_requires_for_build_wheel())
+        for r in hook_caller.get_requires_for_build_wheel():
+            if evaluate_marker(Requirement(r)):
+                requires.add(r)
 
     for req in requires:
         print(f"{req}")


### PR DESCRIPTION
Fixes #21

meson_python is an example of a package with build requirements that depend on the Python version

```
$ python3 ../../../extract-requires.py --build-system 'meson-python>=0.15.0,<0.16.0'
meson >= 1.2.3; python_version >= "3.12"
tomli >= 1.0.0; python_version < "3.11"
pyproject-metadata >= 0.7.1
meson >= 0.63.3; python_version < "3.12"
```

It doesn't make sense for extract-requires.py to output both meson dependency specifications in this example, we should pick the one appropriate for the Python version we're building on.