### PR TITLE
handle multiple versions of python

### DIFF
--- a/install-from-mirror.sh
+++ b/install-from-mirror.sh
@@ -7,7 +7,7 @@ logfile=".install_from_mirror_$(date '+%Y-%m-%d_%H-%M-%S').log"
 exec > >(tee "$logfile") 2>&1
 
 VENV=$(basename $(mktemp --dry-run --directory --tmpdir=. venvXXXX))
-PYTHON=python3.9
+PYTHON=${PYTHON:-python3.9}
 HTTP_SERVER_PID=
 
 on_exit() {

--- a/install-from-mirror.sh
+++ b/install-from-mirror.sh
@@ -39,5 +39,6 @@ pip -vvv install \
     --index-url http://localhost:9090/simple \
     --upgrade \
     "${toplevel}"
+pip freeze
 
 # --dry-run --ignore-installed --report report.json

--- a/install-from-mirror.sh
+++ b/install-from-mirror.sh
@@ -2,12 +2,16 @@
 
 set -xe
 
+WORKDIR=$(realpath $(pwd)/work-dir)
+mkdir -p $WORKDIR
+
+PYTHON=${PYTHON:-python3.9}
+
 # Redirect stdout/stderr to logfile
-logfile=".install_from_mirror_$(date '+%Y-%m-%d_%H-%M-%S').log"
+logfile="$WORKDIR/install-mirror-${PYTHON_VERSION}.log"
 exec > >(tee "$logfile") 2>&1
 
 VENV=$(basename $(mktemp --dry-run --directory --tmpdir=. venvXXXX))
-PYTHON=${PYTHON:-python3.9}
 HTTP_SERVER_PID=
 
 on_exit() {

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -5,10 +5,6 @@ set -o pipefail
 export PS4='+ ${BASH_SOURCE#$HOME/}:$LINENO \011'
 
 WORKDIR=$(realpath $(pwd)/work-dir)
-if [ -d $WORKDIR ]; then
-    echo "Clean up $WORKDIR first"
-    exit 1
-fi
 mkdir -p $WORKDIR
 
 PYTHON=${PYTHON:-python3.9}

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -20,6 +20,7 @@ VENV=$WORKDIR/venv-${PYTHON_VERSION}
 
 WHEELS_REPO=$(realpath $(pwd)/wheels-repo)
 SDISTS_REPO=$(realpath $(pwd)/sdists-repo)
+BUILD_ORDER=${SDISTS_REPO}/build-order-${PYTHON_VERSION}.json
 
 setup() {
   if [ ! -d $VENV ]; then
@@ -45,7 +46,7 @@ add_to_build_order() {
   local type="$1"; shift
   local req="$1"; shift
   local why="$1"; shift
-  jq --argjson obj "{\"type\":\"${type}\",\"req\":\"${req//\"/\'}\",\"why\":\"${why}\"}" '. += [$obj]' ${SDISTS_REPO}/build-order.json > tmp.$$.json && mv tmp.$$.json ${SDISTS_REPO}/build-order.json
+  jq --argjson obj "{\"type\":\"${type}\",\"req\":\"${req//\"/\'}\",\"why\":\"${why}\"}" '. += [$obj]' ${BUILD_ORDER} > tmp.$$.json && mv tmp.$$.json ${BUILD_ORDER}
 }
 
 update_mirror() {
@@ -176,7 +177,7 @@ trap on_exit EXIT SIGINT SIGTERM
 setup
 
 rm -rf ${SDISTS_REPO}/; mkdir -p ${SDISTS_REPO}/downloads/
-echo -n "[]" > ${SDISTS_REPO}/build-order.json
+echo -n "[]" > ${BUILD_ORDER}
 
 rm -rf "${WHEELS_REPO}"
 mkdir -p "${WHEELS_REPO}/downloads"

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -11,14 +11,16 @@ if [ -d $WORKDIR ]; then
 fi
 mkdir -p $WORKDIR
 
+PYTHON=${PYTHON:-python3.9}
+PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
+
 # Redirect stdout/stderr to logfile
-logfile="$WORKDIR/mirror-sdists.log"
+logfile="$WORKDIR/mirror-sdists-${PYTHON_VERSION}.log"
 exec > >(tee "$logfile") 2>&1
 
 TOPLEVEL="${1:-langchain}"
 
-VENV=$WORKDIR/venv
-PYTHON=python3.9
+VENV=$WORKDIR/venv-${PYTHON_VERSION}
 
 WHEELS_REPO=$(realpath $(pwd)/wheels-repo)
 SDISTS_REPO=$(realpath $(pwd)/sdists-repo)

--- a/resolve_and_download.py
+++ b/resolve_and_download.py
@@ -18,7 +18,7 @@ from zipfile import ZipFile
 import html5lib
 import requests
 from packaging.requirements import Requirement
-from packaging.specifiers import SpecifierSet, InvalidSpecifier
+from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.utils import canonicalize_name
 from packaging.version import InvalidVersion, Version
 from resolvelib import (BaseReporter, InconsistentCandidate,
@@ -191,7 +191,7 @@ def download_resolution(destination_dir, result):
         parsed_url = urlparse(candidate.url)
         outfile = os.path.join(destination_dir, os.path.basename(parsed_url.path))
         if os.path.exists(outfile):
-            log(f'already have {outfile}')
+            print(f'\nExisting {outfile}')
             continue
         # Open the URL first in case that fails, so we don't end up with an empty file.
         log(f'reading {candidate.name} {candidate.version} from {candidate.url}')

--- a/test.sh
+++ b/test.sh
@@ -6,7 +6,16 @@ set -o pipefail
 
 toplevel=${1:-langchain}
 
-rm -rf sdists-repo wheels-repo .build* work-dir
-./mirror-sdists.sh "${toplevel}"
+PYTHON_TO_TEST="
+  python3.9
+  python3.12
+"
 
-./install-from-mirror.sh "${toplevel}"
+for PYTHON in $PYTHON_TO_TEST; do
+    PYTHON=$PYTHON ./mirror-sdists.sh "${toplevel}"
+    if PYTHON=$PYTHON ./install-from-mirror.sh "${toplevel}"; then
+        echo "SUCCESS $PYTHON"
+    else
+        echo "FAIL $PYTHON"
+    fi
+done

--- a/test.sh
+++ b/test.sh
@@ -19,9 +19,5 @@ fi
 
 for PYTHON in $PYTHON_TO_TEST; do
     PYTHON=$PYTHON ./mirror-sdists.sh "${toplevel}"
-    if PYTHON=$PYTHON ./install-from-mirror.sh "${toplevel}"; then
-        echo "SUCCESS $PYTHON"
-    else
-        echo "FAIL $PYTHON"
-    fi
+    PYTHON=$PYTHON ./install-from-mirror.sh "${toplevel}"
 done

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,12 @@ PYTHON_TO_TEST="
   python3.12
 "
 
+if ps -f | grep http.server | grep -q python; then
+    existing_server=$(ps -f | grep http.server | grep python | awk '{print $2}')
+    echo "Killing stale web server"
+    kill "${existing_server}"
+fi
+
 for PYTHON in $PYTHON_TO_TEST; do
     PYTHON=$PYTHON ./mirror-sdists.sh "${toplevel}"
     if PYTHON=$PYTHON ./install-from-mirror.sh "${toplevel}"; then


### PR DESCRIPTION
* Treat the work and download directories as reusable.
* Create different log artifacts for each python version.
* Support running with different python interpreters set,
  which should set us verify markers for python version.

Fixes #16