### PR TITLE
ensure wheels are built in isolated environment

### DIFF
--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -86,23 +86,17 @@ build_wheel() {
   local sdist_dir="$1"; shift
 
   local -r unpack_dir=$(dirname "${sdist_dir}")
-  local -r build_env="${unpack_dir}/build-env"
-  $PYTHON -m venv "${build_env}"
-  # FIXME: Still installs 'build' and 'wheel' from outside
+
   (cd "${sdist_dir}"\
-       && source "${build_env}/bin/activate" \
-       && pip install --disable-pip-version-check build wheel \
-       && safe_install -r "${unpack_dir}/build-system-requirements.txt" \
-       && safe_install -r "${unpack_dir}/build-backend-requirements.txt" \
-       && pip freeze \
-       && pwd \
-       && python3 -m build \
-                  --wheel \
-                  --skip-dependency-check \
-                  --no-isolation \
-                  --outdir "${WHEELS_REPO}/downloads/" \
-                  . \
-      )
+       && pip -vvv --disable-pip-version-check \
+              wheel \
+              --index-url "${WHEEL_SERVER_URL}" \
+              --only-binary :all: \
+              --wheel-dir "${WHEELS_REPO}/downloads/" \
+              --no-deps \
+              . \
+    )
+
   update_mirror
 }
 

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -57,7 +57,6 @@ update_mirror() {
 
 build_wheel() {
   local sdist_dir="$1"; shift
-  local dest_dir="$1"; shift
 
   local -r unpack_dir=$(dirname "${sdist_dir}")
   local -r build_env="${unpack_dir}/build-env"
@@ -188,7 +187,7 @@ collect_build_requires() {
 
   # Build the wheel for this package after handling all of the
   # build-related dependencies.
-  build_wheel "${extract_dir}" "${WHEELS_REPO}/downloads"
+  build_wheel "${extract_dir}"
 
   echo "Regular dependencies for ${resolved_name}:"
   (cd ${extract_dir} && $PYTHON $extract_script "${req}") | tee "${normal_deps}"

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -29,9 +29,8 @@ setup() {
     $PYTHON -m venv $VENV
   fi
   . $VENV/bin/activate
-  pip install -U pip
   # Dependencies for the mirror building scripts
-  pip install --upgrade -r ./requirements.txt
+  pip --disable-pip-version-check install --upgrade -r ./requirements.txt
 }
 
 bootstrap_build_dependencies() {

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -31,17 +31,7 @@ setup() {
   . $VENV/bin/activate
   pip install -U pip
   # Dependencies for the mirror building scripts
-  pip install -U \
-      python-pypi-mirror \
-      tomli \
-      pyproject_hooks \
-      packaging \
-      wheel \
-      build \
-      resolvelib \
-      html5lib \
-      requests \
-      packaging
+  pip install --upgrade -r ./requirements.txt
 }
 
 add_to_build_order() {

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -116,6 +116,7 @@ get_downloaded_sdist() {
 
 safe_install() {
   pip -vvv install \
+      --no-cache-dir \
       --upgrade \
       --disable-pip-version-check \
       --only-binary :all: \

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+html5lib
+packaging
+pyproject_hooks
+python-pypi-mirror
+requests
+resolvelib
+tomli


### PR DESCRIPTION
* disable pip cache when installing
* do not upgrade pip in setup
* switch back to use 'pip wheel' for building wheels
* bootstrap build dependencies with flit_core
* misc cleanup

Fixes #23