### PR TITLE
Fix linter errors

### DIFF
--- a/mirror_builder/overrides/__init__.py
+++ b/mirror_builder/overrides/__init__.py
@@ -10,6 +10,7 @@ logger = logging.getLogger(__name__)
 # inputs as mirror_builder.wheels.build_wheel() and returns an
 # iterable that produces the names of wheel files that were created.
 
+
 def find_override_method(distname, method):
     """Given a distname and method name, look for an override implementation of the method.
 

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -7,8 +7,7 @@ import tarfile
 import resolvelib
 from packaging.requirements import Requirement
 
-from . import (dependencies, external_commands, resolve_and_download, server,
-               wheels)
+from . import dependencies, external_commands, resolve_and_download, wheels
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
```
mirror_builder/overrides/__init__.py:13:1: E302 expected 2 blank lines, found 1
mirror_builder/sdist.py:10:1: F401 '.server' imported but unused
```