### PR TITLE
misc. cleanup

### DIFF
--- a/mirror_builder/__main__.py
+++ b/mirror_builder/__main__.py
@@ -5,6 +5,8 @@ import logging
 import os
 import sys
 
+from packaging.requirements import Requirement
+
 from . import context, sdist, server
 
 TERSE_LOG_FMT = '%(message)s'
@@ -37,7 +39,7 @@ def main():
     server.start_wheel_server(ctx)
 
     for toplevel in args.toplevel:
-        sdist.handle_requirement(ctx, toplevel)
+        sdist.handle_requirement(ctx, Requirement(toplevel))
 
 
 if __name__ == '__main__':

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -43,7 +43,7 @@ class WorkContext:
         self._build_requirements.add(resolved_name)
         info = {
             'type': req_type,
-            'req': req,
+            'req': str(req),
             'resolved': resolved_name,
             'why': why,
         }

--- a/mirror_builder/dependencies.py
+++ b/mirror_builder/dependencies.py
@@ -17,7 +17,8 @@ def get_build_system_dependencies(req, sdist_root_dir):
     pyproject_toml = _get_pyproject_contents(sdist_root_dir)
     requires = set()
     for r in get_build_backend(pyproject_toml)['requires']:
-        if evaluate_marker(Requirement(r)):
+        r = Requirement(r)
+        if evaluate_marker(r):
             requires.add(r)
     return requires
 
@@ -29,7 +30,8 @@ def get_build_backend_dependencies(req, sdist_root_dir):
     requires = set()
     hook_caller = get_build_backend_hook_caller(sdist_root_dir, pyproject_toml)
     for r in hook_caller.get_requires_for_build_wheel():
-        if evaluate_marker(Requirement(r)):
+        r = Requirement(r)
+        if evaluate_marker(r):
             requires.add(r)
     return requires
 
@@ -37,7 +39,6 @@ def get_build_backend_dependencies(req, sdist_root_dir):
 def get_install_dependencies(req, sdist_root_dir):
     logger.debug('getting installation dependencies for %s in %s',
                  req, sdist_root_dir)
-    original_requirement = Requirement(req)
     pyproject_toml = _get_pyproject_contents(sdist_root_dir)
     requires = set()
     hook_caller = get_build_backend_hook_caller(sdist_root_dir, pyproject_toml)
@@ -45,8 +46,8 @@ def get_install_dependencies(req, sdist_root_dir):
     with open(os.path.join(sdist_root_dir, metadata_path, "METADATA"), "r") as f:
         parsed = metadata.Metadata.from_email(f.read(), validate=False)
         for r in (parsed.requires_dist or []):
-            if evaluate_marker(r, original_requirement.extras):
-                requires.add(str(r))
+            if evaluate_marker(r, req.extras):
+                requires.add(r)
     return requires
 
 

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -6,7 +6,6 @@ import subprocess
 import tarfile
 
 import resolvelib
-from packaging.requirements import Requirement
 
 from . import dependencies, external_commands, resolve_and_download, wheels
 
@@ -102,7 +101,8 @@ def safe_install(ctx, req, req_type):
         '--index-url', ctx.wheel_server_url,
         f'{req}',
     ])
-    logger.info('installed %s %s', req_type, req)
+    version = importlib.metadata.version(req.name)
+    logger.info('installed %s %s using %s', req_type, req, version)
 
 
 def unpack_sdist(ctx, sdist_filename):
@@ -135,7 +135,6 @@ def _patch_sdist(ctx, sdist_root_dir):
 
 def download_sdist(ctx, requirements):
     "Download the requirement and return the name of the output path."
-    reqs = [Requirement(r) for r in requirements]
 
     # Create the (reusable) resolver.
     provider = resolve_and_download.PyPIProvider()
@@ -143,9 +142,9 @@ def download_sdist(ctx, requirements):
     resolver = resolvelib.Resolver(provider, reporter)
 
     # Kick off the resolution process, and get the final result.
-    logger.debug("resolving requirement %s", ", ".join(requirements))
+    logger.debug("resolving requirement %s", ", ".join(str(r) for r in requirements))
     try:
-        result = resolver.resolve(reqs)
+        result = resolver.resolve(requirements)
     except (resolvelib.InconsistentCandidate,
             resolvelib.RequirementsConflicted,
             resolvelib.ResolutionImpossible) as err:

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -1,7 +1,5 @@
 import logging
 
-from packaging.requirements import Requirement
-
 from . import external_commands, overrides, server
 
 logger = logging.getLogger(__name__)
@@ -9,8 +7,7 @@ logger = logging.getLogger(__name__)
 
 def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
     logger.info('building wheel for %s', resolved_name)
-    r = Requirement(req)
-    builder = overrides.find_override_method(r.name, 'build_wheel')
+    builder = overrides.find_override_method(req.name, 'build_wheel')
     if not builder:
         builder = _default_build_wheel
     wheel_filenames = builder(ctx, req_type, req, resolved_name, why, sdist_root_dir)


### PR DESCRIPTION
* Use packaging.requirements.Requirement internally everywhere. Convert from
  and to str when reading and writing.

* Use the system metadata to see what packages we've already installed and 
  avoid reinstalling them.

* sdist: clean up recursion and mark some functions as private