### PR TITLE
isolate wheel build step from network access

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,6 +10,9 @@ RUN dnf -y groupinstall "Development Tools" "Development Libraries"
 # Commands needed in test.sh
 RUN dnf -y install procps-ng jq patch
 
+# We use firejail to isolate wheel building processes from the internet
+RUN dnf -y install firejail
+
 # cmake needed, otherwise:
 # Building wheels for collected packages: patchelf, ninja
 # ...

--- a/jailed-server.sh
+++ b/jailed-server.sh
@@ -1,3 +1,13 @@
 #!/bin/bash -x
 
-firejail --net=none --name=local-wheel-server python -m http.server -d ./wheels-repo/
+JAIL_NAME=local-wheel-server
+
+existing_pid=$(firejail --list | grep $JAIL_NAME | cut -f1 -d:)
+if [ -n "$existing_pid" ]; then
+    kill $existing_pid
+    # Wait for jail to shutdown
+    sleep 5
+fi
+
+mkdir -p ./wheels-repo/
+firejail --net=none --name=$JAIL_NAME python3 -m http.server -d ./wheels-repo/ &

--- a/jailed-server.sh
+++ b/jailed-server.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -x
+
+firejail --net=none --name=local-wheel-server python -m http.server -d ./wheels-repo/

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -14,6 +14,9 @@ DEFAULT_WORKDIR=$(realpath $(pwd)/work-dir)
 WORKDIR=${WORKDIR:-${DEFAULT_WORKDIR}}
 mkdir -p $WORKDIR
 
+# Start a server for our local wheels directory.
+./jailed-server.sh
+
 PYTHON=${PYTHON:-python3.9}
 PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
 

--- a/mirror_builder/external_commands.py
+++ b/mirror_builder/external_commands.py
@@ -23,6 +23,7 @@ def run(cmd, cwd=None, extra_environ=None):
         stderr=subprocess.STDOUT,
     )
     output = completed.stdout.decode('utf-8') if completed.stdout else ''
-    logger.debug('output: %s', output)
     if completed.returncode != 0:
+        logger.error('output: %s', output)
         raise subprocess.CalledProcessError(completed.returncode, cmd, output)
+    logger.debug('output: %s', output)

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -19,10 +19,13 @@ def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
 
 def _default_build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
     cmd = [
+        'firejail',
+        '--net=none',
+        '--join=local-wheel-server',
         'pip', '-vvv',
         '--disable-pip-version-check',
         'wheel',
-        '--index-url', ctx.wheel_server_url,
+        '--index-url', 'http://127.0.0.1:8000/simple/',
         '--only-binary', ':all:',
         '--wheel-dir', sdist_root_dir.parent.absolute(),
         '--no-deps',

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -25,6 +25,7 @@ def _default_build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir)
         'pip', '-vvv',
         '--disable-pip-version-check',
         'wheel',
+        '--no-cache-dir',
         '--index-url', 'http://127.0.0.1:8000/simple/',
         '--only-binary', ':all:',
         '--wheel-dir', sdist_root_dir.parent.absolute(),


### PR DESCRIPTION
This change puts the wheel building step in an isolated namespace
using firejail. To do that, it creates a namespace with only a loopback
interface and runs a web server for the wheels there.  It then runs `pip
wheel` commands in the same namespace where they can see that server,
but nothing else.

The existing threaded web server is retained for other pip commands that
should be able to run outside of the jail.