### PR TITLE
further isolate wheel build step

### DIFF
--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -14,9 +14,6 @@ DEFAULT_WORKDIR=$(realpath $(pwd)/work-dir)
 WORKDIR=${WORKDIR:-${DEFAULT_WORKDIR}}
 mkdir -p $WORKDIR
 
-# Start a server for our local wheels directory.
-./jailed-server.sh
-
 PYTHON=${PYTHON:-python3.9}
 PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
 

--- a/mirror_builder/overrides/flit_core.py
+++ b/mirror_builder/overrides/flit_core.py
@@ -5,7 +5,7 @@ from mirror_builder import external_commands
 logger = logging.getLogger(__name__)
 
 
-def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def build_wheel(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir):
     # flit_core is a basic build system dependency for several
     # packages. It is capable of building its own wheels, so we use the
     # bootstrapping instructions to do that and put the wheel in the
@@ -15,7 +15,7 @@ def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
     # https://flit.pypa.io/en/stable/bootstrap.html
     logger.info('bootstrapping flit_core wheel in %s', sdist_root_dir)
     external_commands.run(
-        ['python3', '-m', 'flit_core.wheel'],
+        [build_env.python, '-m', 'flit_core.wheel'],
         cwd=sdist_root_dir,
     )
     return (sdist_root_dir / 'dist').glob('*.whl')

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -43,7 +43,8 @@ def handle_requirement(ctx, req, req_type='toplevel', why=''):
         # installed.
         _maybe_install(ctx, dep, next_req_type, resolved)
 
-    wheels.build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir)
+    wheels.build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir,
+                       build_system_dependencies | build_backend_dependencies)
 
     next_req_type = 'dependency'
     install_dependencies = dependencies.get_install_dependencies(req, sdist_root_dir)

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -1,36 +1,71 @@
 import logging
+import platform
+import venv
 
 from . import external_commands, overrides, server
 
 logger = logging.getLogger(__name__)
 
 
-def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir, build_dependencies):
     logger.info('building wheel for %s', resolved_name)
     builder = overrides.find_override_method(req.name, 'build_wheel')
     if not builder:
         builder = _default_build_wheel
-    wheel_filenames = builder(ctx, req_type, req, resolved_name, why, sdist_root_dir)
+    build_env = BuildEnvironment(ctx, sdist_root_dir.parent, build_dependencies)
+    wheel_filenames = builder(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir)
     for wheel in wheel_filenames:
         server.add_wheel_to_mirror(ctx, sdist_root_dir.name, wheel)
     ctx.add_to_build_order(req_type, req, resolved_name, why)
     logger.info('built wheel for %s', resolved_name)
 
 
-def _default_build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def _default_build_wheel(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir):
     cmd = [
-        'firejail',
-        '--net=none',
-        '--join=local-wheel-server',
-        'pip', '-vvv',
+        build_env.python, '-m', 'pip', '-vvv',
         '--disable-pip-version-check',
         'wheel',
         '--no-cache-dir',
-        '--index-url', 'http://127.0.0.1:8000/simple/',
+        '--no-build-isolation',
         '--only-binary', ':all:',
         '--wheel-dir', sdist_root_dir.parent.absolute(),
         '--no-deps',
+        '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
         '.',
     ]
     external_commands.run(cmd, cwd=sdist_root_dir)
     return sdist_root_dir.parent.glob('*.whl')
+
+
+class BuildEnvironment:
+    "Wrapper for a virtualenv used for build isolation."
+
+    def __init__(self, ctx, parent_dir, build_requirements):
+        self._ctx = ctx
+        self._path = parent_dir / f'build-{platform.python_version()}'
+        self._build_requirements = build_requirements
+        self._createenv()
+
+    @property
+    def python(self):
+        return (self._path / 'bin/python3').absolute()
+
+    def _createenv(self):
+        self._builder = venv.EnvBuilder(clear=True, with_pip=True)
+        self._builder.create(self._path)
+        req_filename = self._path / 'requirements.txt'
+        # FIXME: Ensure each requirement is pinned to a specific version.
+        with open(req_filename, 'w') as f:
+            for r in self._build_requirements:
+                f.write(f'{r}\n')
+        external_commands.run(
+            [self.python, '-m', 'pip',
+             'install',
+             '--disable-pip-version-check',
+             '--no-cache-dir',
+             '--only-binary', ':all:',
+             '--index-url', self._ctx.wheel_server_url,
+             '-r', req_filename.absolute(),
+             ],
+            cwd=self._path.parent,
+        )


### PR DESCRIPTION
Pre-configure a virtualenv for building each wheel, including any
identified build pre-requisites.

Remove use of firejail for now because we have some packages that
can't build that way. We can bring it back in a later PR.

Addresses #50