### PR TITLE
pass around a version instead of a resolved_name

### DIFF
--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -14,9 +14,6 @@ DEFAULT_WORKDIR=$(realpath $(pwd)/work-dir)
 WORKDIR=${WORKDIR:-${DEFAULT_WORKDIR}}
 mkdir -p $WORKDIR
 
-# Start a server for our local wheels directory.
-./jailed-server.sh
-
 PYTHON=${PYTHON:-python3.9}
 PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
 

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -39,14 +39,16 @@ class WorkContext:
     def has_been_seen(self, sdist_id):
         return sdist_id in self._seen_requirements
 
-    def add_to_build_order(self, req_type, req, resolved_name, why):
+    def add_to_build_order(self, req_type, req, version, why):
+        resolved_name = f'{req.name}-{version}'
         if resolved_name in self._build_requirements:
             return
         self._build_requirements.add(resolved_name)
         info = {
             'type': req_type,
             'req': str(req),
-            'resolved': resolved_name,
+            'dist': req.name,
+            'version': str(version),
             'why': why,
         }
         self._build_stack.append(info)

--- a/mirror_builder/overrides/flit_core.py
+++ b/mirror_builder/overrides/flit_core.py
@@ -5,7 +5,7 @@ from mirror_builder import external_commands
 logger = logging.getLogger(__name__)
 
 
-def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def build_wheel(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir):
     # flit_core is a basic build system dependency for several
     # packages. It is capable of building its own wheels, so we use the
     # bootstrapping instructions to do that and put the wheel in the
@@ -15,7 +15,7 @@ def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
     # https://flit.pypa.io/en/stable/bootstrap.html
     logger.info('bootstrapping flit_core wheel in %s', sdist_root_dir)
     external_commands.run(
-        ['python3', '-m', 'flit_core.wheel'],
+        [build_env.python, '-m', 'flit_core.wheel'],
         cwd=sdist_root_dir,
     )
     return (sdist_root_dir / 'dist').glob('*.whl')

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -43,7 +43,8 @@ def handle_requirement(ctx, req, req_type='toplevel', why=''):
         # installed.
         _maybe_install(ctx, dep, next_req_type, resolved)
 
-    wheels.build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir)
+    wheels.build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir,
+                       build_system_dependencies | build_backend_dependencies)
 
     next_req_type = 'dependency'
     install_dependencies = dependencies.get_install_dependencies(req, sdist_root_dir)

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -7,20 +7,20 @@ from . import external_commands, overrides, server
 logger = logging.getLogger(__name__)
 
 
-def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir, build_dependencies):
-    logger.info('building wheel for %s', resolved_name)
+def build_wheel(ctx, req_type, req, version, why, sdist_root_dir, build_dependencies):
+    logger.info('building wheel for %s (%s)', req.name, version)
     builder = overrides.find_override_method(req.name, 'build_wheel')
     if not builder:
         builder = _default_build_wheel
     build_env = BuildEnvironment(ctx, sdist_root_dir.parent, build_dependencies)
-    wheel_filenames = builder(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir)
+    wheel_filenames = builder(ctx, build_env, req_type, req, version, why, sdist_root_dir)
     for wheel in wheel_filenames:
         server.add_wheel_to_mirror(ctx, sdist_root_dir.name, wheel)
-    ctx.add_to_build_order(req_type, req, resolved_name, why)
-    logger.info('built wheel for %s', resolved_name)
+    ctx.add_to_build_order(req_type, req, version, why)
+    logger.info('built wheel for %s (%s)', req.name, version)
 
 
-def _default_build_wheel(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir):
+def _default_build_wheel(ctx, build_env, req_type, req, version, why, sdist_root_dir):
     cmd = [
         build_env.python, '-m', 'pip', '-vvv',
         '--disable-pip-version-check',

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -1,36 +1,71 @@
 import logging
+import platform
+import venv
 
 from . import external_commands, overrides, server
 
 logger = logging.getLogger(__name__)
 
 
-def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir, build_dependencies):
     logger.info('building wheel for %s', resolved_name)
     builder = overrides.find_override_method(req.name, 'build_wheel')
     if not builder:
         builder = _default_build_wheel
-    wheel_filenames = builder(ctx, req_type, req, resolved_name, why, sdist_root_dir)
+    build_env = BuildEnvironment(ctx, sdist_root_dir.parent, build_dependencies)
+    wheel_filenames = builder(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir)
     for wheel in wheel_filenames:
         server.add_wheel_to_mirror(ctx, sdist_root_dir.name, wheel)
     ctx.add_to_build_order(req_type, req, resolved_name, why)
     logger.info('built wheel for %s', resolved_name)
 
 
-def _default_build_wheel(ctx, req_type, req, resolved_name, why, sdist_root_dir):
+def _default_build_wheel(ctx, build_env, req_type, req, resolved_name, why, sdist_root_dir):
     cmd = [
-        'firejail',
-        '--net=none',
-        '--join=local-wheel-server',
-        'pip', '-vvv',
+        build_env.python, '-m', 'pip', '-vvv',
         '--disable-pip-version-check',
         'wheel',
         '--no-cache-dir',
-        '--index-url', 'http://127.0.0.1:8000/simple/',
+        '--no-build-isolation',
         '--only-binary', ':all:',
         '--wheel-dir', sdist_root_dir.parent.absolute(),
         '--no-deps',
+        '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
         '.',
     ]
     external_commands.run(cmd, cwd=sdist_root_dir)
     return sdist_root_dir.parent.glob('*.whl')
+
+
+class BuildEnvironment:
+    "Wrapper for a virtualenv used for build isolation."
+
+    def __init__(self, ctx, parent_dir, build_requirements):
+        self._ctx = ctx
+        self._path = parent_dir / f'build-{platform.python_version()}'
+        self._build_requirements = build_requirements
+        self._createenv()
+
+    @property
+    def python(self):
+        return (self._path / 'bin/python3').absolute()
+
+    def _createenv(self):
+        self._builder = venv.EnvBuilder(clear=True, with_pip=True)
+        self._builder.create(self._path)
+        req_filename = self._path / 'requirements.txt'
+        # FIXME: Ensure each requirement is pinned to a specific version.
+        with open(req_filename, 'w') as f:
+            for r in self._build_requirements:
+                f.write(f'{r}\n')
+        external_commands.run(
+            [self.python, '-m', 'pip',
+             'install',
+             '--disable-pip-version-check',
+             '--no-cache-dir',
+             '--only-binary', ':all:',
+             '--index-url', self._ctx.wheel_server_url,
+             '-r', req_filename.absolute(),
+             ],
+            cwd=self._path.parent,
+        )

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -12,22 +12,24 @@ def test_seen(tmp_context):
 
 def test_build_order(tmp_context):
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), 'buildme-6.0', ' -> buildme')
+        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme')
     tmp_context.add_to_build_order(
-        'dependency', Requirement('testdist>1.0'), 'testdist-1.2', ' -> testdist')
+        'dependency', Requirement('testdist>1.0'), '1.2', ' -> testdist')
     contents_str = tmp_context._build_order_filename.read_text()
     contents = json.loads(contents_str)
     expected = [
         {
             'type': 'build_backend',
             'req': 'buildme>1.0',
-            'resolved': 'buildme-6.0',
+            'dist': 'buildme',
+            'version': '6.0',
             'why': ' -> buildme',
         },
         {
             'type': 'dependency',
             'req': 'testdist>1.0',
-            'resolved': 'testdist-1.2',
+            'dist': 'testdist',
+            'version': '1.2',
             'why': ' -> testdist',
         },
     ]
@@ -36,16 +38,17 @@ def test_build_order(tmp_context):
 
 def test_build_order_repeats(tmp_context):
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), 'buildme-6.0', ' -> buildme')
+        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme')
     tmp_context.add_to_build_order(
-        'build_backend', Requirement('buildme>1.0'), 'buildme-6.0', ' -> buildme')
+        'build_backend', Requirement('buildme>1.0'), '6.0', ' -> buildme')
     contents_str = tmp_context._build_order_filename.read_text()
     contents = json.loads(contents_str)
     expected = [
         {
             'type': 'build_backend',
             'req': 'buildme>1.0',
-            'resolved': 'buildme-6.0',
+            'dist': 'buildme',
+            'version': '6.0',
             'why': ' -> buildme',
         },
     ]


### PR DESCRIPTION
Instead of passing a string that can't be parsed properly, just pass the
version. Everywhere we use the version we have a Requirement to get the
name from. Still track the resolved_name form as a key in the
"seen" set.