### PR TITLE
fix workdir in container test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -58,11 +58,4 @@ jobs:
 
       - name: Run tests
         run: |
-          podman run --rm \
-            --userns=keep-id \
-            --security-opt label=disable \
-            --volume .:/src:rw,exec \
-            -e PYTHON_TO_TEST=python${{ matrix.python-version }} \
-            -e VERBOSE=-v \
-            test-${{ matrix.python-version }} \
-            ./test.sh
+          PYTHON=python${{ matrix.python-version }} ./test_container.sh

--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@ __pycache__/
 .*.log
 /sdists-repo/
 /wheels-repo/
-/work-dir/
+/work-dir*/
 /test-venv/
 /venv*/
-/container-work-dir/
 /build/
 /mirror_builder.egg-info/
 /mirror_builder/version.py

--- a/install-from-mirror.sh
+++ b/install-from-mirror.sh
@@ -2,7 +2,8 @@
 
 set -xe
 
-WORKDIR=$(realpath $(pwd)/work-dir)
+DEFAULT_WORKDIR=$(realpath $(pwd)/work-dir)
+WORKDIR=${WORKDIR:-${DEFAULT_WORKDIR}}
 mkdir -p $WORKDIR
 
 PYTHON=${PYTHON:-python3.9}

--- a/mirror_builder/__main__.py
+++ b/mirror_builder/__main__.py
@@ -19,7 +19,7 @@ def main():
     parser.add_argument('-v', '--verbose', action='store_true', default=False)
     parser.add_argument('-o', '--sdists-repo', default='sdists-repo')
     parser.add_argument('-w', '--wheels-repo', default='wheels-repo')
-    parser.add_argument('-t', '--work-dir', default=os.environ.get('WORK_DIR', 'work-dir'))
+    parser.add_argument('-t', '--work-dir', default=os.environ.get('WORKDIR', 'work-dir'))
     parser.add_argument('--wheel-server-port', default=0, type=int)
     args = parser.parse_args(sys.argv[1:])
 


### PR DESCRIPTION
* Fix the scripts so they inherit the WORKDIR variable properly.
* Decouple test_container.sh from test.sh by running mirror-sdists.sh
  and install-from-mirror.sh separately in test_container.sh.
* Fix the python program default for getting the work dir to use the
  right environment variable.