### PR TITLE
e2e: pass $PYTHON to test script

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -90,4 +90,4 @@ jobs:
 
       - name: Run tests
         run: |
-          ${{ matrix.test-script }}
+          PYTHON=python${{ matrix.python-version }} ${{ matrix.test-script }}


### PR DESCRIPTION
Fixes:

```
e2e/common.sh: line 17: python3.12: command not found
```

in the 3.9 test job