### PR TITLE
reduce the places we use the python version in an output path

### DIFF
--- a/e2e/test_rebuild_following_bootstrap.sh
+++ b/e2e/test_rebuild_following_bootstrap.sh
@@ -73,7 +73,7 @@ BOOTSTRAP_OUTPUT=$WORKDIR/bootstrap-output.txt
 find wheels-repo/downloads > $BOOTSTRAP_OUTPUT
 
 # Look at the bootstrap command output to decide which wheels to build.
-REBUILD_ORDER_FILE=${WORKDIR}/build-order-${PYTHON_VERSION}.json
+REBUILD_ORDER_FILE=${WORKDIR}/build-order.json
 
 # Recreate sdists-repo and wheels-repo so they are rebuilt as we build
 # those wheels again.

--- a/mirror-sdists.sh
+++ b/mirror-sdists.sh
@@ -20,10 +20,10 @@ PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
 TOPLEVEL="${1:-langchain}"
 
 # Redirect stdout/stderr to logfile
-logfile="$WORKDIR/mirror-sdists-${PYTHON_VERSION}.log"
+logfile="$WORKDIR/mirror-sdists.log"
 exec > >(tee "$logfile") 2>&1
 
-VENV="${WORKDIR}/venv-${PYTHON}"
+VENV="${WORKDIR}/venv"
 # Create a fresh virtualenv every time since the process installs
 # packages into it.
 rm -rf "${VENV}"

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import pathlib
-import platform
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,7 @@ class WorkContext:
         self.work_dir = pathlib.Path(work_dir).absolute()
         self.wheel_server_port = wheel_server_port
 
-        self._build_order_filename = self.work_dir / f'build-order-{platform.python_version()}.json'
+        self._build_order_filename = self.work_dir / 'build-order.json'
 
         # Push items onto the stack as we start to resolve their
         # dependencies so at the end we have a list of items that need to

--- a/test.sh
+++ b/test.sh
@@ -11,11 +11,18 @@ PYTHON_TO_TEST="
   python3.12
 "
 
-WORKDIR=$(realpath $(pwd)/work-dir)
-mkdir -p $WORKDIR
 
 for PYTHON in $PYTHON_TO_TEST; do
-    PYTHON=$PYTHON ./mirror-sdists.sh "${toplevel}"
+    export PYTHON
+    PYTHON_VERSION=$($PYTHON --version | cut -f2 -d' ')
+
+    WORKDIR=$(pwd)/work-dir-${PYTHON_VERSION}
+    export WORKDIR
+    mkdir -p $WORKDIR
+
+    ./mirror-sdists.sh "${toplevel}"
+
     find wheels-repo/simple/ -name '*.whl'
-    PYTHON=$PYTHON ./install-from-mirror.sh "${toplevel}"
+
+    ./install-from-mirror.sh "${toplevel}"
 done


### PR DESCRIPTION
test.sh builds for multiple versions of python for testing. Instead of
spreading that requirement throughout the code, have test.sh create a
separate working directory and let everything else use consistent naming.