### PR TITLE
demonstrate building with containers

### DIFF
--- a/.containerignore
+++ b/.containerignore
@@ -1,0 +1,12 @@
+**/__pycache__/*
+*.egg-info/*
+*.log
+.cache/*
+.cargo/*
+.git/*
+.tox/*
+.venv/*
+sdists-repo/*
+venv*
+wheels-repo/*
+work-dir/*

--- a/Containerfile.e2e
+++ b/Containerfile.e2e
@@ -46,4 +46,13 @@ RUN dnf -y install zlib-devel libjpeg-devel
 # python3.12-devel needed for 3.12 builds (on CentOS Stream 9)
 RUN dnf -y install python3.9 python3.12 python3.12-devel
 
+RUN python3.12 -m venv /venv \
+    && /venv/bin/pip install --upgrade pip
+
+ENV VIRTUAL_ENV=/venv
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+
+COPY . /mirror-builder
+RUN pip install /mirror-builder
+
 WORKDIR /src

--- a/Containerfile.e2e-bootstrap
+++ b/Containerfile.e2e-bootstrap
@@ -1,0 +1,16 @@
+FROM e2e-build-base
+
+# Which package should be bootstrapped?
+ARG TOPLEVEL
+
+ENV VIRTUAL_ENV=/venv
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+
+RUN python3 -m mirror_builder -v \
+    --work-dir /work-dir \
+    --sdists-repo /sdists-repo \
+    --wheels-repo /wheels-repo \
+    bootstrap ${TOPLEVEL}
+
+FROM scratch
+COPY --from=0 /work-dir/build-order.json /bootstrap/build-order.json

--- a/Containerfile.e2e-one-wheel
+++ b/Containerfile.e2e-one-wheel
@@ -1,0 +1,68 @@
+FROM e2e-build-base
+
+# Which package should be built?
+ARG DIST
+ARG VERSION
+
+ENV VIRTUAL_ENV=/venv
+ENV PATH=$VIRTUAL_ENV/bin:$PATH
+
+RUN mkdir /sdists-repo && mkdir /work-dir && mkdir /build-logs
+
+# Download the source archive
+RUN python3 -m mirror_builder -v \
+    --work-dir /work-dir \
+    --sdists-repo /sdists-repo \
+    --wheels-repo /wheels-repo \
+    download-source-archive ${DIST} ${VERSION} \
+    2>&1 | tee /build-logs/download-source-archive.log
+
+
+FROM e2e-build-base
+COPY --from=0 /sdists-repo /sdists-repo
+COPY --from=0 /build-logs /build-logs
+
+# Which package should be built?
+ARG DIST
+ARG VERSION
+
+RUN mkdir /work-dir
+
+# Prepare the source dir for building
+RUN python3 -m mirror_builder -v \
+    --work-dir /work-dir \
+    --sdists-repo /sdists-repo \
+    --wheels-repo /wheels-repo \
+    prepare-source ${DIST} ${VERSION} /sdists-repo/downloads/${DIST}*.tar.gz \
+    2>&1 | tee /build-logs/prepare-source.log
+
+
+FROM e2e-build-base
+COPY --from=0 /sdists-repo /sdists-repo
+COPY --from=1 /work-dir /work-dir
+COPY --from=1 /build-logs /build-logs
+COPY e2e/container_build.sh /work-dir
+
+# Which package should be built?
+ARG DIST
+ARG VERSION
+
+# Where do we find dependencies?
+ARG WHEEL_SERVER_URL
+
+ENV DIST=${DIST}
+ENV VERSION=${VERSION}
+
+# Prepare the build environment
+RUN python3 -m mirror_builder -v \
+    --work-dir /work-dir \
+    --sdists-repo /sdists-repo \
+    --wheels-repo /wheels-repo \
+    --wheel-server-url ${WHEEL_SERVER_URL} \
+    prepare-build ${DIST} ${VERSION} /work-dir/${DIST}*/${DIST}* \
+    2>&1 | tee /build-logs/prepare-build.log
+
+
+WORKDIR /build-dir
+
+ENTRYPOINT /work-dir/container_build.sh

--- a/e2e/container_build.sh
+++ b/e2e/container_build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -x
+set -ue -o pipefail
+
+source /venv/bin/activate
+
+python3 -m mirror_builder \
+        --wheel-server-url "$WHEEL_SERVER_URL" \
+        -v \
+        --work-dir $(pwd) \
+        --sdists-repo /sdists-repo \
+        --wheels-repo /wheels-repo \
+        build "$DIST" "$VERSION" /work-dir/${DIST}*/${DIST}* \
+        2>&1 | tee /build-logs/build.log
+
+tar cvf /work-dir/built-artifacts.tar /wheels-repo/build /sdists-repo/downloads /build-logs

--- a/mirror_builder/__main__.py
+++ b/mirror_builder/__main__.py
@@ -78,8 +78,6 @@ def do_bootstrap(ctx, args):
 def do_download_source_archive(ctx, args):
     req = Requirement(f'{args.dist_name}=={args.dist_version}')
     filename, _ = sources.download_source(ctx, req)
-    with open(ctx.work_dir / 'last-download.txt', 'w') as f:
-        f.write(filename)
     print(filename)
 
 
@@ -88,8 +86,6 @@ def do_prepare_source(ctx, args):
     source_filename = pathlib.Path(args.source_archive)
     # FIXME: Does the version need to be a Version instead of str?
     source_root_dir = sources.prepare_source(ctx, req, source_filename, args.dist_version)
-    with open(ctx.work_dir / 'last-source-dir.txt', 'w') as f:
-        f.write(str(source_root_dir))
     print(source_root_dir)
 
 
@@ -105,10 +101,8 @@ def do_build(ctx, args):
     source_root_dir = pathlib.Path(args.source_dir)
     build_env = wheels.BuildEnvironment(ctx, source_root_dir.parent, None)
     wheel_filenames = wheels.build_wheel(ctx, req, source_root_dir, build_env)
-    with open(ctx.work_dir / 'last-wheels.txt', 'w') as f:
-        for filename in wheel_filenames:
-            f.write(f'{filename}\n')
-            print(filename)
+    for filename in wheel_filenames:
+        print(filename)
 
 
 if __name__ == '__main__':

--- a/mirror_builder/__main__.py
+++ b/mirror_builder/__main__.py
@@ -10,6 +10,8 @@ from packaging.requirements import Requirement
 
 from . import context, sdist, server, sources, wheels
 
+logger = logging.getLogger(__name__)
+
 TERSE_LOG_FMT = '%(message)s'
 VERBOSE_LOG_FMT = '%(levelname)s:%(name)s:%(lineno)d: %(message)s'
 
@@ -20,7 +22,7 @@ def main():
     parser.add_argument('-o', '--sdists-repo', default='sdists-repo')
     parser.add_argument('-w', '--wheels-repo', default='wheels-repo')
     parser.add_argument('-t', '--work-dir', default=os.environ.get('WORKDIR', 'work-dir'))
-    parser.add_argument('--wheel-server-port', default=0, type=int)
+    parser.add_argument('--wheel-server-url')
 
     subparsers = parser.add_subparsers(title='commands', dest='command')
 
@@ -62,7 +64,7 @@ def main():
         sdists_repo=args.sdists_repo,
         wheels_repo=args.wheels_repo,
         work_dir=args.work_dir,
-        wheel_server_port=args.wheel_server_port,
+        wheel_server_url=args.wheel_server_url,
     )
     ctx.setup()
 
@@ -77,12 +79,14 @@ def do_bootstrap(ctx, args):
 
 def do_download_source_archive(ctx, args):
     req = Requirement(f'{args.dist_name}=={args.dist_version}')
+    logger.info('downloading source archive for %s', req)
     filename, _ = sources.download_source(ctx, req)
     print(filename)
 
 
 def do_prepare_source(ctx, args):
     req = Requirement(f'{args.dist_name}=={args.dist_version}')
+    logger.info('preparing source directory for %s', req)
     source_filename = pathlib.Path(args.source_archive)
     # FIXME: Does the version need to be a Version instead of str?
     source_root_dir = sources.prepare_source(ctx, req, source_filename, args.dist_version)
@@ -92,12 +96,14 @@ def do_prepare_source(ctx, args):
 def do_prepare_build(ctx, args):
     server.start_wheel_server(ctx)
     req = Requirement(f'{args.dist_name}=={args.dist_version}')
+    logger.info('preparing build environment for %s', req)
     source_root_dir = pathlib.Path(args.source_dir)
     sdist.prepare_build_environment(ctx, req, source_root_dir)
 
 
 def do_build(ctx, args):
     req = Requirement(f'{args.dist_name}=={args.dist_version}')
+    logger.info('building for %s', req)
     source_root_dir = pathlib.Path(args.source_dir)
     build_env = wheels.BuildEnvironment(ctx, source_root_dir.parent, None)
     wheel_filenames = wheels.build_wheel(ctx, req, source_root_dir, build_env)

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -11,6 +11,7 @@ class WorkContext:
         self.sdists_repo = pathlib.Path(sdists_repo).absolute()
         self.sdists_downloads = self.sdists_repo / 'downloads'
         self.wheels_repo = pathlib.Path(wheels_repo).absolute()
+        self.wheels_build = self.wheels_repo / 'build'
         self.wheels_downloads = self.wheels_repo / 'downloads'
         self.wheel_server_dir = self.wheels_repo / 'simple'
         self.work_dir = pathlib.Path(work_dir).absolute()

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -1,13 +1,14 @@
 import json
 import logging
 import pathlib
+from urllib.parse import urlparse
 
 logger = logging.getLogger(__name__)
 
 
 class WorkContext:
 
-    def __init__(self, sdists_repo, wheels_repo, work_dir, wheel_server_port):
+    def __init__(self, sdists_repo, wheels_repo, work_dir, wheel_server_url):
         self.sdists_repo = pathlib.Path(sdists_repo).absolute()
         self.sdists_downloads = self.sdists_repo / 'downloads'
         self.wheels_repo = pathlib.Path(wheels_repo).absolute()
@@ -15,7 +16,7 @@ class WorkContext:
         self.wheels_downloads = self.wheels_repo / 'downloads'
         self.wheel_server_dir = self.wheels_repo / 'simple'
         self.work_dir = pathlib.Path(work_dir).absolute()
-        self.wheel_server_port = wheel_server_port
+        self.wheel_server_url = wheel_server_url
 
         self._build_order_filename = self.work_dir / 'build-order.json'
 
@@ -31,6 +32,16 @@ class WorkContext:
         # than the package, in case we do have multiple rules for the same
         # package.
         self._seen_requirements = set()
+
+    @property
+    def pip_wheel_server_args(self):
+        args = ['--index-url', self.wheel_server_url]
+        parsed = urlparse(self.wheel_server_url)
+        if parsed.scheme != 'https':
+            args = args + [
+                '--trusted-host', parsed.hostname
+            ]
+        return args
 
     def mark_as_seen(self, sdist_id):
         logger.debug('remembering seen sdist %s', sdist_id)
@@ -65,7 +76,3 @@ class WorkContext:
             if not p.exists():
                 logger.debug('creating %s', p)
                 p.mkdir(parents=True)
-
-    @property
-    def wheel_server_url(self):
-        return f'http://localhost:{self.wheel_server_port}/simple/'

--- a/mirror_builder/overrides/flit_core.py
+++ b/mirror_builder/overrides/flit_core.py
@@ -15,7 +15,7 @@ def build_wheel(ctx, build_env, req, sdist_root_dir):
     # https://flit.pypa.io/en/stable/bootstrap.html
     logger.info('bootstrapping flit_core wheel in %s', sdist_root_dir)
     external_commands.run(
-        [build_env.python, '-m', 'flit_core.wheel'],
+        [build_env.python, '-m', 'flit_core.wheel',
+         '--outdir', ctx.wheels_build],
         cwd=sdist_root_dir,
     )
-    return (sdist_root_dir / 'dist').glob('*.whl')

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -127,7 +127,7 @@ def safe_install(ctx, req, req_type):
         '--no-cache-dir',
         '--upgrade',
         '--only-binary', ':all:',
-        '--index-url', ctx.wheel_server_url,
+    ] + ctx.pip_wheel_server_args + [
         f'{req}',
     ])
     version = importlib.metadata.version(req.name)

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -48,10 +48,10 @@ def handle_requirement(ctx, req, req_type='toplevel', why=''):
         ctx, sdist_root_dir.parent,
         build_system_dependencies | build_backend_dependencies,
     )
-    wheel_filenames = wheels.build_wheel(ctx, req, sdist_root_dir, build_env)
-    for wheel in wheel_filenames:
-        server.add_wheel_to_mirror(ctx, sdist_root_dir.name, wheel)
+    wheels.build_wheel(ctx, req, sdist_root_dir, build_env)
+    server.update_wheel_mirror(ctx)
     logger.info('built wheel for %s (%s)', req.name, resolved_version)
+    ctx.mark_as_seen(sdist_root_dir.name)
     ctx.add_to_build_order(req_type, req, resolved_version, why)
 
     next_req_type = 'dependency'

--- a/mirror_builder/server.py
+++ b/mirror_builder/server.py
@@ -17,9 +17,11 @@ class LoggingHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
 
 def start_wheel_server(ctx):
     update_wheel_mirror(ctx)
-    logger.debug('wheel port %s', ctx.wheel_server_port)
+    if ctx.wheel_server_url:
+        logger.debug('using external wheel server at %s', ctx.wheel_server_url)
+        return
     server = http.server.ThreadingHTTPServer(
-        ('localhost', ctx.wheel_server_port),
+        ('localhost', 0),
         functools.partial(LoggingHTTPRequestHandler, directory=ctx.wheels_repo),
         bind_and_activate=False,
     )
@@ -28,7 +30,7 @@ def start_wheel_server(ctx):
 
     logger.debug(f'address {server.server_address}')
     server.server_bind()
-    ctx.wheel_server_port = server.server_port  # in case a port was allocated for us
+    ctx.wheel_server_url = f'http://localhost:{server.server_port}/simple/'
 
     logger.debug('starting wheel server at %s', ctx.wheel_server_url)
     server.server_activate()

--- a/mirror_builder/server.py
+++ b/mirror_builder/server.py
@@ -15,13 +15,6 @@ class LoggingHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         logger.debug(format, *args)
 
 
-def add_wheel_to_mirror(ctx, name_version, filename):
-    logger.debug('copying wheel %s to mirror', filename)
-    shutil.copyfile(filename, ctx.wheels_downloads / filename.name)
-    update_wheel_mirror(ctx)
-    ctx.mark_as_seen(name_version)
-
-
 def start_wheel_server(ctx):
     update_wheel_mirror(ctx)
     logger.debug('wheel port %s', ctx.wheel_server_port)
@@ -51,6 +44,9 @@ def start_wheel_server(ctx):
 
 def update_wheel_mirror(ctx):
     logger.debug('updating wheel mirror')
+    for wheel in ctx.wheels_build.glob('*.whl'):
+        logger.debug('adding %s', wheel)
+        shutil.move(wheel, ctx.wheels_downloads / wheel.name)
     external_commands.run([
         'pypi-mirror',
         'create',

--- a/mirror_builder/wheels.py
+++ b/mirror_builder/wheels.py
@@ -1,5 +1,6 @@
 import logging
 import platform
+import tempfile
 import venv
 
 from . import external_commands, overrides
@@ -18,19 +19,20 @@ def build_wheel(ctx, req, sdist_root_dir, build_env):
 
 
 def _default_build_wheel(ctx, build_env, req, sdist_root_dir):
-    cmd = [
-        build_env.python, '-m', 'pip', '-vvv',
-        '--disable-pip-version-check',
-        'wheel',
-        '--no-cache-dir',
-        '--no-build-isolation',
-        '--only-binary', ':all:',
-        '--wheel-dir', ctx.wheels_build,
-        '--no-deps',
-        '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
-        '.',
-    ]
-    external_commands.run(cmd, cwd=sdist_root_dir)
+    with tempfile.TemporaryDirectory() as dir_name:
+        cmd = [
+            build_env.python, '-m', 'pip', '-vvv',
+            '--disable-pip-version-check',
+            'wheel',
+            '--no-cache-dir',
+            '--no-build-isolation',
+            '--only-binary', ':all:',
+            '--wheel-dir', ctx.wheels_build,
+            '--no-deps',
+            '--index-url', ctx.wheel_server_url,  # probably redundant, but just in case
+            sdist_root_dir,
+        ]
+        external_commands.run(cmd, cwd=dir_name)
 
 
 class BuildEnvironment:
@@ -53,20 +55,24 @@ class BuildEnvironment:
         logger.debug('creating build environment in %s', self.path)
         self._builder = venv.EnvBuilder(clear=True, with_pip=True)
         self._builder.create(self.path)
+        logger.info('created build environment in %s', self.path)
         req_filename = self.path / 'requirements.txt'
         # FIXME: Ensure each requirement is pinned to a specific version.
         with open(req_filename, 'w') as f:
-            for r in self._build_requirements:
-                f.write(f'{r}\n')
+            if self._build_requirements:
+                for r in self._build_requirements:
+                    f.write(f'{r}\n')
+        if not self._build_requirements:
+            return
         external_commands.run(
             [self.python, '-m', 'pip',
              'install',
              '--disable-pip-version-check',
              '--no-cache-dir',
              '--only-binary', ':all:',
-             '--index-url', self._ctx.wheel_server_url,
-             '-r', req_filename.absolute(),
+             ] + self._ctx.pip_wheel_server_args + [
+                 '-r', req_filename.absolute(),
              ],
             cwd=self.path.parent,
         )
-        logger.info('created build environment in %s', self.path)
+        logger.info('installed dependencies into build environment in %s', self.path)


### PR DESCRIPTION
Rewrite the e2e bootstrap test so it uses containers to isolate each step of the build.

Use a base image to install dependencies and a builder image to set up the build environment. Run the builder without network access to demonstrate that we're getting everything we need into the image. Copy the artifacts out of the container to the host filesystem, including the sdist, wheel, and all logs.

Fixes #68 