### PR TITLE
move recursion management all into handle_requirement()

### DIFF
--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -31,12 +31,15 @@ class WorkContext:
         # package.
         self._seen_requirements = set()
 
-    def mark_as_seen(self, sdist_id):
-        logger.debug('remembering seen sdist %s', sdist_id)
-        self._seen_requirements.add(sdist_id)
+    def _resolved_key(self, req, version):
+        return (req.name, str(version))
 
-    def has_been_seen(self, sdist_id):
-        return sdist_id in self._seen_requirements
+    def mark_as_seen(self, req, version):
+        logger.debug('remembering seen sdist %s', self._resolved_key(req, version))
+        self._seen_requirements.add(self._resolved_key(req, version))
+
+    def has_been_seen(self, req, version):
+        return self._resolved_key(req, version) in self._seen_requirements
 
     def add_to_build_order(self, req_type, req, version, why):
         resolved_name = f'{req.name}-{version}'

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -8,14 +8,16 @@ logger = logging.getLogger(__name__)
 
 def handle_requirement(ctx, req, req_type='toplevel', why=''):
     source_filename, resolved_version = sources.download_source(ctx, req)
-    sdist_root_dir = sources.prepare_source(ctx, req, source_filename, resolved_version)
 
     # Avoid cyclic dependencies and redundant processing.
-    if sdist_root_dir is None:
+    if ctx.has_been_seen(req, resolved_version):
         logger.debug(f'redundant requirement {req} resolves to {resolved_version}')
-        return
+        return resolved_version
+    ctx.mark_as_seen(req, resolved_version)
 
     logger.info('new dependency (%s) %s -> %s resolves to %s', req_type, why, req, resolved_version)
+
+    sdist_root_dir = sources.prepare_source(ctx, req, source_filename, resolved_version)
 
     next_why = f'{why} -> {req.name}({resolved_version})'
     next_req_type = 'build_system'

--- a/mirror_builder/server.py
+++ b/mirror_builder/server.py
@@ -19,7 +19,6 @@ def add_wheel_to_mirror(ctx, name_version, filename):
     logger.debug('copying wheel %s to mirror', filename)
     shutil.copyfile(filename, ctx.wheels_downloads / filename.name)
     update_wheel_mirror(ctx)
-    ctx.mark_as_seen(name_version)
 
 
 def start_wheel_server(ctx):

--- a/mirror_builder/sources.py
+++ b/mirror_builder/sources.py
@@ -100,11 +100,6 @@ def prepare_source(ctx, req, source_filename, version):
 
 
 def _default_prepare_source(ctx, req, source_filename, version):
-    resolved_name = f'{req.name}-{version}'
-    if ctx.has_been_seen(resolved_name):
-        return None
-    ctx.mark_as_seen(resolved_name)
-
     source_root_dir = unpack_source(ctx, source_filename)
     _patch_source(ctx, source_root_dir)
     return source_root_dir

--- a/tests/test_context.py
+++ b/tests/test_context.py
@@ -4,10 +4,11 @@ from packaging.requirements import Requirement
 
 
 def test_seen(tmp_context):
-    distid = 'testdist-1.2'
-    assert not tmp_context.has_been_seen(distid)
-    tmp_context.mark_as_seen(distid)
-    assert tmp_context.has_been_seen(distid)
+    req = Requirement('testdist')
+    version = '1.2'
+    assert not tmp_context.has_been_seen(req, version)
+    tmp_context.mark_as_seen(req, version)
+    assert tmp_context.has_been_seen(req, version)
 
 
 def test_build_order(tmp_context):


### PR DESCRIPTION
Centralize the management of recursion for bootstrapping in
handle_requirement().

Give the requirement and version to the context as separate arguments
to determine if something has been seen already, instead of building
the unique id outside of the context where it's stored.