### PR TITLE
clean up build working dir by default

### DIFF
--- a/mirror_builder/__main__.py
+++ b/mirror_builder/__main__.py
@@ -21,6 +21,7 @@ def main():
     parser.add_argument('-w', '--wheels-repo', default='wheels-repo')
     parser.add_argument('-t', '--work-dir', default=os.environ.get('WORKDIR', 'work-dir'))
     parser.add_argument('--wheel-server-port', default=0, type=int)
+    parser.add_argument('--no-cleanup', dest='cleanup', default=True, action='store_false')
 
     subparsers = parser.add_subparsers(title='commands', dest='command')
 
@@ -63,6 +64,7 @@ def main():
         wheels_repo=args.wheels_repo,
         work_dir=args.work_dir,
         wheel_server_port=args.wheel_server_port,
+        cleanup=args.cleanup,
     )
     ctx.setup()
 

--- a/mirror_builder/context.py
+++ b/mirror_builder/context.py
@@ -7,7 +7,7 @@ logger = logging.getLogger(__name__)
 
 class WorkContext:
 
-    def __init__(self, sdists_repo, wheels_repo, work_dir, wheel_server_port):
+    def __init__(self, sdists_repo, wheels_repo, work_dir, wheel_server_port, cleanup=True):
         self.sdists_repo = pathlib.Path(sdists_repo).absolute()
         self.sdists_downloads = self.sdists_repo / 'downloads'
         self.wheels_repo = pathlib.Path(wheels_repo).absolute()
@@ -15,6 +15,7 @@ class WorkContext:
         self.wheel_server_dir = self.wheels_repo / 'simple'
         self.work_dir = pathlib.Path(work_dir).absolute()
         self.wheel_server_port = wheel_server_port
+        self.cleanup = cleanup
 
         self._build_order_filename = self.work_dir / 'build-order.json'
 

--- a/mirror_builder/sdist.py
+++ b/mirror_builder/sdist.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 import logging
+import shutil
 
 from . import dependencies, external_commands, server, sources, wheels
 
@@ -62,6 +63,16 @@ def handle_requirement(ctx, req, req_type='toplevel', why=''):
     )
     for dep in install_dependencies:
         handle_requirement(ctx, dep, next_req_type, next_why)
+
+    # Cleanup the source tree and build environment, leaving any other
+    # artifacts that were created.
+    if ctx.cleanup:
+        logger.debug('cleaning up source tree %s', sdist_root_dir)
+        shutil.rmtree(sdist_root_dir)
+        logger.debug('cleaned up source tree %s', sdist_root_dir)
+        logger.debug('cleaning up build environment %s', build_env.path)
+        shutil.rmtree(build_env.path)
+        logger.debug('cleaned up build environment %s', build_env.path)
 
     return resolved_version
 


### PR DESCRIPTION
Remove the source tree and the virtualenv used to build each package
by default when bootstrapping.