### PR TITLE
This repo has moved to Gitlab at this URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# MOVED
+
+This repo has moved to: https://gitlab.com/fedora/sigs/ai-ml/rebuilding-the-wheel
+
 # Rebuilding the Wheel
 
 This repo is a prototype of completely re-building a dependency tree of Python wheels from source.


### PR DESCRIPTION
https://gitlab.com/fedora/sigs/ai-ml/rebuilding-the-wheel